### PR TITLE
Remove docker completion

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -11,7 +11,6 @@ brew "gh" # https://github.com/cli/cli
 brew "hub" # https://github.com/mislav/hub
 brew "gnupg" # https://github.com/gpg/gnupg
 brew "docker" # https://github.com/docker/cli
-brew "docker-completion" # https://github.com/docker/cli
 brew "marp-cli" # https://github.com/marp-team/marp-cli
 brew "starship" # https://github.com/starship/starship
 brew "php" # https://github.com/php/php-src


### PR DESCRIPTION
Modern `docker` formula ships its own shell completions (zsh, fish, bash). The separate `docker-completion` formula conflicts with `docker`'s bundled completions, causing symlink errors that break `brew bundle` entirely during upgrades.

## Error encountered

```
Error: The `brew link` step did not complete successfully
Could not symlink etc/bash_completion.d/docker
Target /opt/homebrew/etc/bash_completion.d/docker
is a symlink belonging to docker-completion.
```

This caused `brew bundle` to exit with `1 Brewfile dependency failed to install`, blocking the entire `gmake update` run.

## Changes
- Remove `brew "docker-completion"` from Brewfile
- `docker`'s own completions are installed automatically when `docker` is installed or upgraded