### PR TITLE
Blackfire trust

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ install:## 📦 Install dependencies
 		eval /opt/homebrew/bin/brew shellenv
 		brew trust symfony-cli/tap
 		brew trust box-project/box
+		brew trust blackfireio/blackfire
 		brew bundle
 
 		###> rectangle ###
@@ -44,6 +45,9 @@ install:## 📦 Install dependencies
 		killall Finder
 
 update:	## 🔄 Update everything, first cli and then casks
+		brew trust symfony-cli/tap
+		brew trust box-project/box
+		brew trust blackfireio/blackfire
 		brew bundle
 
 		@grep '^cask "' Brewfile | \


### PR DESCRIPTION
The `blackfireio/blackfire` tap was untrusted by Homebrew's trust mechanism. During `gmake update`, the tap was silently ignored and its packages skipped. The Makefile already ran `brew trust` for `symfony-cli/tap` and `box-project/box` before `brew bundle` — `blackfireio/blackfire` needed the same treatment.

## Error encountered

```
Warning: The following taps are not trusted:
  blackfireio/blackfire

Homebrew is currently ignoring formulae, casks and commands from these taps
because tap trust is required.
```

## Changes
- Add `brew trust blackfireio/blackfire` to the `install` target, alongside the two existing trust commands
- Add all three `brew trust` commands (`symfony-cli/tap`, `box-project/box`, `blackfireio/blackfire`) to the `update` target, which was previously missing them entirely