### PR TITLE
Fix brew shellenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 install:## 📦 Install dependencies
 		sudo true
 		curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh | /bin/bash
-		eval /opt/homebrew/bin/brew shellenv
+		export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$(PATH)"
 		brew trust symfony-cli/tap
 		brew trust box-project/box
 		brew bundle


### PR DESCRIPTION
Each line in a Makefile runs in its own subshell. The previous `eval /opt/homebrew/bin/brew shellenv` evaluated the shell environment but the effect died with that subshell — subsequent lines in the `install` target had no `brew` on their PATH, causing `brew trust` and `brew bundle` to fail with "command not found: brew" on a fresh machine.

## Changes
- Replace `eval /opt/homebrew/bin/brew shellenv` with `export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$(PATH)"`
- `export` in a Make recipe sets an environment variable that Make propagates to all child processes for the rest of the target, unlike `eval` which only affects the single subshell