### PR TITLE
Remove docker brew formula

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -9,7 +9,6 @@ brew "git-delta" # https://github.com/dandavison/delta
 brew "act" # https://github.com/nektos/act
 brew "gh" # https://github.com/cli/cli
 brew "gnupg" # https://github.com/gpg/gnupg
-brew "docker" # https://github.com/docker/cli
 brew "marp-cli" # https://github.com/marp-team/marp-cli
 brew "starship" # https://github.com/starship/starship
 brew "php" # https://github.com/php/php-src


### PR DESCRIPTION
Docker Desktop (cask) ships its own CLI binary at `/usr/local/bin/docker`. Having the brew `docker` formula alongside `docker-desktop` caused two problems confirmed during a real `gmake update` run:

1. **PATH shadowing** — Homebrew warned that its `docker` binary was shadowed by Docker Desktop's binary at `/usr/local/bin/docker`
2. **Symlink conflict** — When upgrading `docker`, Homebrew failed to create completion symlinks because `docker-completion` already owned them, blocking the entire `brew bundle` run

## Changes
- Remove `brew "docker"` from Brewfile
- Keep `cask "docker-desktop"` which includes both the GUI and CLI