### PR TITLE
Remove hub formula, superseded by gh

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -8,7 +8,6 @@ brew "bat" # https://github.com/sharkdp/bat
 brew "git-delta" # https://github.com/dandavison/delta
 brew "act" # https://github.com/nektos/act
 brew "gh" # https://github.com/cli/cli
-brew "hub" # https://github.com/mislav/hub
 brew "gnupg" # https://github.com/gpg/gnupg
 brew "docker" # https://github.com/docker/cli
 brew "docker-completion" # https://github.com/docker/cli


### PR DESCRIPTION
`hub` is in maintenance-only mode and has been superseded by `gh` (the official GitHub CLI). Both tools wrap git with GitHub-specific commands and intercept git aliases, which can cause conflicts. Since `gh` is already in the Brewfile and covers all the same functionality, `hub` is redundant.

## Changes
- Remove `brew "hub"` from Brewfile
- `brew "gh"` remains unchanged