### PR TITLE
Upgrade installed formulae in update target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ update:	## 🔄 Update everything, first cli and then casks
 		brew trust symfony-cli/tap
 		brew trust box-project/box
 		brew trust blackfireio/blackfire
+		brew upgrade
 		brew bundle
 
 		@grep '^cask "' Brewfile | \


### PR DESCRIPTION
`brew bundle` without flags only installs *missing* packages — it does not upgrade already-installed formulae. The `update` target had a separate loop to upgrade casks, but formulae were silently left at their current versions between runs of `gmake update`.

## Changes
- Add `brew upgrade` before `brew bundle` in the `update` target
- This ensures all installed formulae are upgraded, while `brew bundle` then reconciles any additions or removals from the Brewfile