### PR TITLE
Add idempotency guards to install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 install:## 📦 Install dependencies
 		sudo true
-		curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh | /bin/bash
+		command -v brew > /dev/null 2>&1 || curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh | /bin/bash
 		export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$(PATH)"
 		brew trust symfony-cli/tap
 		brew trust box-project/box
@@ -28,7 +28,7 @@ install:## 📦 Install dependencies
 		###< phpstorm ###
 
 		###> zsh ###
-		curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh | sudo -u $$USER bash
+		[ -d "$$HOME/.oh-my-zsh" ] || curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh | sudo -u $$USER bash
 		cp templates/.zshrc ~/.zshrc
 		echo "alias gmake='make -f $(PWD)/Makefile'" >> ~/.zshrc
 		###< zsh ###


### PR DESCRIPTION
Running `make install` twice would attempt to reinstall Homebrew and Oh-My-Zsh. The Homebrew installer fails loudly on a system where it is already installed; the Oh-My-Zsh installer may partially overwrite existing configuration. Neither had any guard against re-runs.

## Changes
- **Homebrew**: skip the installer if `brew` is already on PATH
  ```makefile
  command -v brew > /dev/null 2>&1 || curl -fsSL .../install.sh | /bin/bash
  ```
- **Oh-My-Zsh**: skip the installer if `~/.oh-my-zsh` already exists
  ```makefile
  [ -d "$$HOME/.oh-my-zsh" ] || curl -fsSL .../install.sh | sudo -u $$USER bash
  ```