### PR TITLE
Add pinentry-mac to install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@ install:## 📦 Install dependencies
 		blackfire php:install
 		###< blackfire ###
 
+		###> gpg ###
+		brew install pinentry-mac
+		###< gpg ###
+
 		###> xdebug ###
 		pecl install xdebug
 		###< xdebug ###


### PR DESCRIPTION
`pinentry-mac` is required for GPG commit signing to work on macOS — it is the GUI passphrase entry program that `gpg-agent` delegates to. Without it, GPG-signed commits fail silently after a fresh install. The setup is documented in `gpg.md` but the package was never automated.

## Changes
- Add a `###> gpg ###` section to the `install` target with `brew install pinentry-mac`
- Follows the same section marker style (`###> ... ###`) used throughout the Makefile