### PR TITLE
Add claude-code cask to Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -40,6 +40,7 @@ cask "insomnia" # https://github.com/Kong/insomnia
 cask "rectangle" # https://github.com/rxhanson/Rectangle
 cask "slack" # https://github.com/slackhq/slack-desktop
 cask "claude" # https://claude.ai
+cask "claude-code" # https://claude.ai/code
 cask "sublime-text" # https://github.com/sublimehq/sublime_text
 cask "superwhisper" # https://superwhisper.com
 cask "the-unarchiver" # https://github.com/MacPaw/XADMaster


### PR DESCRIPTION
Claude Code (the AI CLI/desktop tool) should be part of the standard toolset installed on a fresh Mac, alongside the existing `cask "claude"`.

## Changes
- Add `cask "claude-code" # https://claude.ai/code` immediately after `cask "claude"` in Brewfile