### PR TITLE
Add Brewfile.local override support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Brewfile.lock.json
+Brewfile.local
 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ install:## 📦 Install dependencies
 		brew trust box-project/box
 		brew trust blackfireio/blackfire
 		brew bundle
+		[ -f Brewfile.local ] && brew bundle --file Brewfile.local || true
 
 		###> rectangle ###
 		xattr -r -d com.apple.quarantine /Applications/Rectangle.app
@@ -54,6 +55,7 @@ update:	## 🔄 Update everything, first cli and then casks
 		brew trust blackfireio/blackfire
 		brew upgrade
 		brew bundle
+		[ -f Brewfile.local ] && brew bundle --file Brewfile.local || true
 
 		@grep '^cask "' Brewfile | \
 		sed 's/^cask "\(.*\)"/\1/' | \


### PR DESCRIPTION
Allows machine-specific packages without modifying the tracked Brewfile. Useful for separating work tools from personal tools across different machines.

## Changes
- Add `Brewfile.local` to `.gitignore`
- In `install` and `update` targets: load `Brewfile.local` when present (`[ -f Brewfile.local ] && brew bundle --file Brewfile.local || true`)