### PR TITLE
Add SSH setup documentation and config template

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,9 @@ install:## 📦 Install dependencies
 		mkdir -p ~/.config
 		cp templates/starship.toml ~/.config/starship.toml
 		cp templates/com.googlecode.iterm2.plist ~/Library/Preferences/com.googlecode.iterm2.plist
+		mkdir -p ~/.ssh
+		cp templates/.ssh_config ~/.ssh/config
+		chmod 600 ~/.ssh/config
 		###< templates ###
 
 		defaults write com.apple.finder AppleShowAllFiles TRUE

--- a/ssh.md
+++ b/ssh.md
@@ -1,0 +1,29 @@
+# SSH
+
+Generate an ED25519 SSH key:
+
+```console
+ssh-keygen -t ed25519 -C "your_email@example.com"
+```
+
+Add the key to the macOS keychain:
+
+```console
+ssh-add --apple-use-keychain ~/.ssh/id_ed25519
+```
+
+Copy the public key:
+
+```console
+pbcopy < ~/.ssh/id_ed25519.pub
+```
+
+Add it to GitHub at https://github.com/settings/ssh/new.
+
+Test the connection:
+
+```console
+ssh -T git@github.com
+```
+
+You should see: `Hi username! You've successfully authenticated, but GitHub does not provide shell access.`

--- a/templates/.ssh_config
+++ b/templates/.ssh_config
@@ -1,0 +1,4 @@
+Host *
+  AddKeysToAgent yes
+  UseKeychain yes
+  IdentityFile ~/.ssh/id_ed25519


### PR DESCRIPTION
GPG setup is documented in \`gpg.md\` but SSH setup was missing. A fresh Mac needs SSH key generation and GitHub configuration.

## Changes
- Add `ssh.md` with step-by-step instructions: ED25519 key generation, macOS keychain integration, copying public key to GitHub, testing the connection
- Add `templates/.ssh_config` with `AddKeysToAgent yes`, `UseKeychain yes`, `IdentityFile ~/.ssh/id_ed25519`
- Wire into Makefile `install` templates section: `mkdir -p ~/.ssh`, copy config, `chmod 600`