### PR TITLE
Add git aliases to .gitconfig template

### DIFF
--- a/templates/.gitconfig
+++ b/templates/.gitconfig
@@ -45,3 +45,13 @@
 
 [diff]
     colorMoved = default
+
+[alias]
+	st = status
+	co = checkout
+	br = branch
+	ci = commit
+	lg = log --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit
+	last = log -1 HEAD
+	unstage = reset HEAD --
+	aliases = config --get-regexp alias


### PR DESCRIPTION
The \`.gitconfig\` template had no aliases section. Common shortcuts speed up daily workflow.

## Changes
- Add `[alias]` section to `templates/.gitconfig` with: `st`, `co`, `br`, `ci`, `lg` (graph log), `last`, `unstage`, `aliases`