### PR TITLE
Add .editorconfig for consistent formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[Makefile]
+indent_style = tab
+
+[*.{md,toml,yml,yaml}]
+indent_style = space
+indent_size = 2
+
+[*.{json,rb}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Ensures consistent formatting across editors for contributors to this repo.

## Changes
- Add `.editorconfig` at repo root
- LF line endings, final newline, trim trailing whitespace, UTF-8 for all files
- Tab indentation for Makefile
- 2-space indentation for `md`, `toml`, `yml`, `yaml`, `json`, `rb`