### PR TITLE
Add topgrade.toml config template

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,8 @@ install:## 📦 Install dependencies
 		mkdir -p ~/.config
 		cp templates/starship.toml ~/.config/starship.toml
 		cp templates/com.googlecode.iterm2.plist ~/Library/Preferences/com.googlecode.iterm2.plist
+		mkdir -p ~/.config/topgrade
+		cp templates/topgrade.toml ~/.config/topgrade.toml
 		###< templates ###
 
 		defaults write com.apple.finder AppleShowAllFiles TRUE

--- a/templates/topgrade.toml
+++ b/templates/topgrade.toml
@@ -1,0 +1,7 @@
+[misc]
+assume_yes = true
+no_retry = true
+disable = ["node", "composer"]
+
+[brew]
+greedy_casks = true


### PR DESCRIPTION
\`topgrade\` is installed via Brewfile but had no config. A template centralises update settings and avoids interactive prompts.

## Changes
- Add `templates/topgrade.toml` with `assume_yes`, `no_retry`, `disable = ["node", "composer"]`, `greedy_casks = true`
- Wire into Makefile `install` templates section: create `~/.config/topgrade/` and copy the template