### PR TITLE
Add glow to Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -23,6 +23,7 @@ brew "zsh-fast-syntax-highlighting" # https://github.com/zdharma-continuum/fast-
 brew "zsh-vi-mode" # https://github.com/jeffreytse/zsh-vi-mode
 brew "box-project/box/box" # https://github.com/box-project/box
 brew "asciinema" # https://github.com/asciinema/asciinema
+brew "glow" # https://github.com/charmbracelet/glow
 brew "tree" # https://github.com/Old-Man-Programmer/tree
 brew "mkcert" # https://github.com/FiloSottile/mkcert
 brew "nss" # https://github.com/nss-dev/nss


### PR DESCRIPTION
Adds `glow` for rendering Markdown in the terminal — useful for reading `README.md`, `gpg.md`, `ssh.md` and other docs directly in the shell without leaving the terminal.