### PR TITLE
Pin Homebrew/actions/setup-homebrew to a fixed release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@1f8e202ffddf94def7f42f6fa3a482e821489f9c # 2026.07.10.1
 
       - name: Validate Brewfile
         run: brew bundle check --no-upgrade || brew bundle list


### PR DESCRIPTION
## Summary
- CI was warning that `Homebrew/actions/setup-homebrew@master` is deprecated and will start failing once Homebrew 5.2.0 ships
- Pinned the action to the recommended commit SHA (`1f8e202`, release `2026.07.10.1`)

## Test plan
- [ ] Confirm the CI workflow run passes with the pinned action