### PR TITLE
Fix gmake alias to work outside the repo directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ install:## 📦 Install dependencies
 		###> zsh ###
 		[ -d "$$HOME/.oh-my-zsh" ] || curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh | sudo -u $$USER bash
 		cp templates/.zshrc ~/.zshrc
-		echo "alias gmake='make -f $(PWD)/Makefile'" >> ~/.zshrc
+		echo "alias gmake='make -C $(PWD) -f $(PWD)/Makefile'" >> ~/.zshrc
 		###< zsh ###
 
 		###> templates ###


### PR DESCRIPTION
## Summary
- The `gmake` alias generated by `make install` used `make -f <path>/Makefile`, which only tells `make` which Makefile to read — it doesn't change the working directory
- `brew bundle` looks for `Brewfile` in the current directory, so running `gmake install`/`update` from outside the repo failed to find it
- Changed the alias to `make -C <path> -f <path>/Makefile` so `make` also `cd`s into the repo before running

## Test plan
- [ ] Run `make install` (or re-source `~/.zshrc` with the new alias) and confirm `gmake update` works from an arbitrary directory