### PR TITLE
Add maccy to the common package

### DIFF
--- a/packages/common.mk
+++ b/packages/common.mk
@@ -23,6 +23,7 @@ common-install: ## Install common tools and apps
 		brew install --cask iterm2 # https://github.com/gnachman/iTerm2
 		brew install --cask insomnia # https://github.com/Kong/insomnia
 		brew install --cask rectangle # https://github.com/rxhanson/Rectangle
+		brew install --cask maccy # https://github.com/p0deje/Maccy
 		brew install --cask slack # https://github.com/slackhq/slack-desktop
 		brew install --cask claude # https://claude.ai
 		brew install --cask claude-code # https://claude.ai/code
@@ -46,6 +47,6 @@ common-update: common-install ## Update common tools and apps
 
 common-remove: ## Remove common tools and apps
 		brew uninstall --force --ignore-dependencies lsd bat gnupg pinentry-mac marp-cli starship asciinema glow tree mkcert nss act ansible
-		brew uninstall --cask --force --ignore-dependencies --zap font-hack-nerd-font docker-desktop brave-browser brave-browser@beta firefox bitwarden iterm2 insomnia rectangle slack claude claude-code sublime-text superwhisper the-unarchiver
+		brew uninstall --cask --force --ignore-dependencies --zap font-hack-nerd-font docker-desktop brave-browser brave-browser@beta firefox bitwarden iterm2 insomnia rectangle maccy slack claude claude-code sublime-text superwhisper the-unarchiver
 		rm -f ~/.config/starship.toml
 		rm -f ~/Library/Preferences/com.googlecode.iterm2.plist


### PR DESCRIPTION
## Summary
- Adds `maccy` (https://github.com/p0deje/Maccy, MIT license) as a Homebrew cask in `packages/common.mk`
- Maccy is a lightweight clipboard manager for macOS — a general desktop app used regardless of language/stack, so it belongs in `common.mk` alongside tools like `rectangle` and `insomnia`
- No extra config needed; just the install line, plus adding it to the `common-remove` uninstall list

## Test plan
- [x] `make --dry-run common-install` shows `brew install --cask maccy # https://github.com/p0deje/Maccy` in the output
- [x] `make --dry-run common-remove` shows `maccy` included in the `brew uninstall --cask ...` list
- [x] Both dry-run commands exit 0 (no Makefile syntax errors)
- [x] `make help` still renders the full target list correctly