### PR TITLE
Add rclone to the common package

### DIFF
--- a/packages/common.mk
+++ b/packages/common.mk
@@ -11,6 +11,7 @@ common-install: ## Install common tools and apps
 		brew install glow # https://github.com/charmbracelet/glow
 		brew install tree # https://github.com/Old-Man-Programmer/tree
 		brew install mkcert # https://github.com/FiloSottile/mkcert
+		brew install rclone # https://github.com/rclone/rclone
 		brew install nss # https://github.com/nss-dev/nss
 		brew install act # https://github.com/nektos/act
 		brew install ansible # https://github.com/ansible/ansible
@@ -45,7 +46,7 @@ common-install: ## Install common tools and apps
 common-update: common-install ## Update common tools and apps
 
 common-remove: ## Remove common tools and apps
-		brew uninstall --force --ignore-dependencies lsd bat gnupg pinentry-mac marp-cli starship asciinema glow tree mkcert nss act ansible
+		brew uninstall --force --ignore-dependencies lsd bat gnupg pinentry-mac marp-cli starship asciinema glow tree mkcert nss act ansible rclone
 		brew uninstall --cask --force --ignore-dependencies --zap font-hack-nerd-font docker-desktop brave-browser brave-browser@beta firefox bitwarden iterm2 insomnia rectangle slack claude claude-code sublime-text superwhisper the-unarchiver
 		rm -f ~/.config/starship.toml
 		rm -f ~/Library/Preferences/com.googlecode.iterm2.plist


### PR DESCRIPTION
## Summary
- Adds `rclone` (https://github.com/rclone/rclone, MIT), a cloud-storage sync/rsync-like CLI tool, as a new Homebrew formula in `packages/common.mk`.
- Placed in `common.mk` (not a language-specific package file) since it's a general-purpose tool used regardless of stack.
- Also adds `rclone` to the `common-remove` uninstall list so it can be cleanly removed.

## Test plan
- [x] `make --dry-run common-install` shows `brew install rclone # https://github.com/rclone/rclone` in the right place
- [x] `make --dry-run common-remove` shows `rclone` appended to the `brew uninstall --force --ignore-dependencies ...` line
- [x] `make help` still renders the full target list with no errors