### PR TITLE
Add bats-core to the common package

### DIFF
--- a/packages/common.mk
+++ b/packages/common.mk
@@ -14,6 +14,7 @@ common-install: ## Install common tools and apps
 		brew install rclone # https://github.com/rclone/rclone
 		brew install nss # https://github.com/nss-dev/nss
 		brew install act # https://github.com/nektos/act
+		brew install bats-core # https://github.com/bats-core/bats-core
 		brew install ansible # https://github.com/ansible/ansible
 		brew install --cask font-hack-nerd-font # https://github.com/ryanoasis/nerd-fonts
 		brew install --cask docker-desktop # https://github.com/docker/for-mac
@@ -47,7 +48,7 @@ common-install: ## Install common tools and apps
 common-update: common-install ## Update common tools and apps
 
 common-remove: ## Remove common tools and apps
-		brew uninstall --force --ignore-dependencies lsd bat gnupg pinentry-mac marp-cli starship asciinema glow tree mkcert nss act ansible rclone
+		brew uninstall --force --ignore-dependencies lsd bat gnupg pinentry-mac marp-cli starship asciinema glow tree mkcert nss act ansible rclone bats-core
 		brew uninstall --cask --force --ignore-dependencies --zap font-hack-nerd-font docker-desktop brave-browser brave-browser@beta firefox bitwarden iterm2 insomnia rectangle maccy slack claude claude-code sublime-text superwhisper the-unarchiver
 		rm -f ~/.config/starship.toml
 		rm -f ~/Library/Preferences/com.googlecode.iterm2.plist


### PR DESCRIPTION
## Summary
- Adds `bats-core` (https://github.com/bats-core/bats-core), the Bash Automated Testing System, as a Homebrew formula in `packages/common.mk`
- It's a general-purpose shell/Bash testing framework, not tied to any specific language toolchain, so it belongs in `common.mk` alongside other stack-agnostic CLI tools like `glow`, `tree`, `mkcert`, and `act`
- Also adds `bats-core` to the `common-remove` uninstall list so it's cleaned up consistently with the other common tools

## Test plan
- [x] `make --dry-run common-install` shows `brew install bats-core # https://github.com/bats-core/bats-core` in the correct position, exits 0
- [x] `make --dry-run common-remove` shows `bats-core` appended to the `brew uninstall --force --ignore-dependencies ...` list, exits 0
- [x] `make help` renders the full target list with no errors