### PR TITLE
Install zsh-autosuggestions, zsh-vi-mode and fast-syntax-highlighting…

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ entries live in there:
   `zsh-fast-syntax-highlighting` Homebrew formula name it used to have.
 
 See the [oh-my-zsh Customization wiki](https://github.com/ohmyzsh/ohmyzsh/wiki/Customization)
-for how `$ZSH_CUSTOM` and the `plugins=()` array work.
+for how `$ZSH_CUSTOM` and the `plugins=()` array work, and the
+[full bundled plugins list](https://github.com/ohmyzsh/ohmyzsh/wiki/plugins)
+for what else oh-my-zsh ships that could be enabled here.
 
 ## Customize .plist file
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,26 @@ make remove             # every package, plus Homebrew itself
 make php-remove         # a single package's brews/casks only
 ```
 
+## zsh plugins
+
+All plugins in `templates/.zshrc` load through a single mechanism: the
+`plugins=(...)` array, read by `source $ZSH/oh-my-zsh.sh`. Two kinds of
+entries live in there:
+
+- **Bundled with oh-my-zsh**: `git`, `docker`, `docker-compose`, `composer`,
+  `symfony`, `macos`, `brew`, `history-substring-search`.
+- **Custom plugins** (`zsh-autosuggestions`, `zsh-vi-mode`,
+  `fast-syntax-highlighting`) — not bundled with oh-my-zsh, so `packages/zsh.mk`
+  git-clones them straight into `$ZSH_CUSTOM/plugins/<name>/` instead of
+  installing them via Homebrew. oh-my-zsh's loader only picks up a plugin if
+  it finds a file at `$ZSH_CUSTOM/plugins/<name>/<name>.plugin.zsh`, so each
+  clone's directory name has to match its own plugin file — that's why the
+  third one is named `fast-syntax-highlighting` here rather than the
+  `zsh-fast-syntax-highlighting` Homebrew formula name it used to have.
+
+See the [oh-my-zsh Customization wiki](https://github.com/ohmyzsh/ohmyzsh/wiki/Customization)
+for how `$ZSH_CUSTOM` and the `plugins=()` array work.
+
 ## Customize .plist file
 
 1. Copy the file you want from `~/Library/Preferences`

--- a/packages/zsh.mk
+++ b/packages/zsh.mk
@@ -1,19 +1,26 @@
 # zsh plugins and shell config.
 
 zsh-install: ## Install zsh plugins and shell config
-		brew install zsh-autosuggestions # https://github.com/zsh-users/zsh-autosuggestions
-		brew install zsh-fast-syntax-highlighting # https://github.com/zdharma-continuum/fast-syntax-highlighting
-		brew install zsh-vi-mode # https://github.com/jeffreytse/zsh-vi-mode
-
 		# oh-my-zsh: https://ohmyz.sh
 		[ -d "$$HOME/.oh-my-zsh" ] || curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh | sudo -u $$USER bash
+
+		# Installed as oh-my-zsh custom plugins (not Homebrew) so they load
+		# through the plugins=() array like the bundled ones. Directory names
+		# must match each plugin's own <name>.plugin.zsh file.
+		[ -d ~/.oh-my-zsh/custom/plugins/zsh-autosuggestions ] || git clone https://github.com/zsh-users/zsh-autosuggestions ~/.oh-my-zsh/custom/plugins/zsh-autosuggestions
+		[ -d ~/.oh-my-zsh/custom/plugins/zsh-vi-mode ] || git clone https://github.com/jeffreytse/zsh-vi-mode ~/.oh-my-zsh/custom/plugins/zsh-vi-mode
+		[ -d ~/.oh-my-zsh/custom/plugins/fast-syntax-highlighting ] || git clone https://github.com/zdharma-continuum/fast-syntax-highlighting ~/.oh-my-zsh/custom/plugins/fast-syntax-highlighting
+
 		cp templates/.zshrc ~/.zshrc
 		echo "alias gmake='make -C $(PWD) -f $(PWD)/Makefile'" >> ~/.zshrc
 
-zsh-update: zsh-install ## Update zsh plugins and shell config
+zsh-update: ## Update zsh plugins and shell config
+		git -C ~/.oh-my-zsh/custom/plugins/zsh-autosuggestions pull
+		git -C ~/.oh-my-zsh/custom/plugins/zsh-vi-mode pull
+		git -C ~/.oh-my-zsh/custom/plugins/fast-syntax-highlighting pull
+		$(MAKE) zsh-install
 
 zsh-remove: ## Remove zsh plugins and shell config
-		brew uninstall --force --ignore-dependencies zsh-autosuggestions zsh-fast-syntax-highlighting zsh-vi-mode
 		chmod a+x ~/.oh-my-zsh/tools/uninstall.sh
 		~/.oh-my-zsh/tools/uninstall.sh
 		rm -f ~/.zshrc

--- a/templates/.zshrc
+++ b/templates/.zshrc
@@ -15,6 +15,12 @@ plugins=(
 source $ZSH/oh-my-zsh.sh
 
 alias cat='bat --theme=Dracula'
+# `gdc` follows the oh-my-zsh git plugin's alias naming convention (short,
+# git-prefixed mnemonics like gdca/gdcw/gdct), but that plugin doesn't define
+# a plain `gdc`, so it's safe to add here without colliding with it:
+# https://github.com/ohmyzsh/ohmyzsh/blob/master/plugins/git/git.plugin.zsh
+# Staged diff, skipping lockfiles so reviews stay focused on real changes.
+alias gdc="git diff --cached -- ':!*.lock*' ':!*-lock*'"
 eval "$(starship init zsh)"
 export GPG_TTY=$(tty)
 

--- a/templates/.zshrc
+++ b/templates/.zshrc
@@ -1,15 +1,24 @@
-autoload -Uz compinit
-compinit
-source $(brew --prefix)/share/zsh-autosuggestions/zsh-autosuggestions.zsh
-source $(brew --prefix)/opt/zsh-vi-mode/share/zsh-vi-mode/zsh-vi-mode.plugin.zsh
-source $(brew --prefix)/opt/zsh-fast-syntax-highlighting/share/zsh-fast-syntax-highlighting/fast-syntax-highlighting.plugin.zsh
+export ZSH="$HOME/.oh-my-zsh"
+plugins=(
+  git
+  docker
+  docker-compose
+  composer
+  symfony
+  macos
+  brew
+  history-substring-search
+  zsh-autosuggestions
+  zsh-vi-mode
+  fast-syntax-highlighting
+)
+source $ZSH/oh-my-zsh.sh
+
 alias cat='bat --theme=Dracula'
 eval "$(starship init zsh)"
 export GPG_TTY=$(tty)
-if command -v symfony &>/dev/null; then
-    eval "$(symfony completion)"
-fi
 
+unalias ls 2>/dev/null
 ls() {
     # Call lsd and handle output line by line
     command lsd --color=always --icon=always "$@" | while IFS= read -r line; do

--- a/templates/.zshrc
+++ b/templates/.zshrc
@@ -18,7 +18,7 @@ alias cat='bat --theme=Dracula'
 # `gdc` follows the oh-my-zsh git plugin's alias naming convention (short,
 # git-prefixed mnemonics like gdca/gdcw/gdct), but that plugin doesn't define
 # a plain `gdc`, so it's safe to add here without colliding with it:
-# https://github.com/ohmyzsh/ohmyzsh/blob/master/plugins/git/git.plugin.zsh
+# https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/git
 # Staged diff, skipping lockfiles so reviews stay focused on real changes.
 alias gdc="git diff --cached -- ':!*.lock*' ':!*-lock*'"
 eval "$(starship init zsh)"

--- a/templates/.zshrc
+++ b/templates/.zshrc
@@ -1,4 +1,5 @@
 export ZSH="$HOME/.oh-my-zsh"
+# Full list of bundled oh-my-zsh plugins: https://github.com/ohmyzsh/ohmyzsh/wiki/plugins
 plugins=(
   git
   docker


### PR DESCRIPTION
… via oh-my-zsh

Clones them as oh-my-zsh custom plugins instead of Homebrew formulae, so all zsh plugins now load through the same plugins=() array rather than splitting between that and manual source lines. zsh-update now git-pulls each clone since brew upgrade no longer covers them.

#23 