### PR TITLE
Remove git-delta pager and its Homebrew install

### DIFF
--- a/packages/git.mk
+++ b/packages/git.mk
@@ -1,7 +1,6 @@
 # git-related CLI tools and config.
 
 git-install: ## Install git tools and config
-		brew install git-delta # https://github.com/dandavison/delta
 		brew install gh # https://github.com/cli/cli
 
 		cp templates/.gitignore ~/.gitignore
@@ -10,5 +9,5 @@ git-install: ## Install git tools and config
 git-update: git-install ## Update git tools and config
 
 git-remove: ## Remove git tools and config
-		brew uninstall --force --ignore-dependencies git-delta gh
+		brew uninstall --force --ignore-dependencies gh
 		rm -f ~/.gitignore

--- a/templates/.gitconfig
+++ b/templates/.gitconfig
@@ -29,16 +29,9 @@
     whitespace = trailing-space
 	autocrlf = input
 	eol = lf
-    pager = delta
 
 [branch]
 	sort = committerdate
-
-[interactive]
-    diffFilter = delta --color-only
-
-[delta]
-    navigate = true    # use n and N to move between diff sections
 
 [merge]
     conflictstyle = diff3


### PR DESCRIPTION
## Summary
- Removed `core.pager = delta`, `interactive.diffFilter`, and the `[delta]` section from `templates/.gitconfig`
- Removed `brew install git-delta` (and its uninstall line) from `packages/git.mk`
- Git now uses its plain built-in diff coloring/pager

## Why
delta's bundled `DotENV` syntax grammar barely highlights `.env` files — confirmed across every bundled theme (Dracula, Nord, Monokai Extended, etc.), and delta has no option to remap a filename to a different, richer grammar. Removing it for now rather than living with the inconsistency.

## Test plan
- [ ] Run `make git-install` and confirm `~/.gitconfig` no longer references delta
- [ ] Confirm `git diff` still shows normal red/green coloring via git's built-in pager